### PR TITLE
Upload provenance report as artifact for CLI access

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -79,10 +79,14 @@ jobs:
         run: |
           echo "## Signal Provenance Report" >> $GITHUB_STEP_SUMMARY
           cat build/signal_provenance_report.md >> $GITHUB_STEP_SUMMARY
-          echo -e "\n\n## Raw JSON Data" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          cat build/signal_provenance_report.json >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload provenance report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: provenance-report
+          path: |
+            build/signal_provenance_report.md
+            build/signal_provenance_report.json
 
       - name: Checkout schemas repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Enables the obdb CLI tool to download and display the full provenance report (signal/command counts and contributing repositories) from workflow runs without needing to parse logs.

Also removes raw JSON output from workflow summary that was bloating the GitHub UI.

Uses actions/upload-artifact to make both the markdown summary and JSON report available for download via 'gh run download'.